### PR TITLE
Add support to build image with a specific rclone version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,22 @@
+FROM lsiobase/alpine:3.11 as downloader
+
+ARG VERSION=current
+
+RUN apk --no-cache add ca-certificates curl unzip
+
+#Fetch and unpack
+RUN if [ "${VERSION}" != 'current' ]; then FOLDER="/${VERSION}"; fi; curl -O https://downloads.rclone.org/${FOLDER}/rclone-${VERSION}-linux-amd64.zip
+RUN unzip rclone-${VERSION}-linux-amd64.zip -d rclone_unzip && \
+   cd rclone_unzip/* && \
+   mv rclone /rclone
+
 FROM lsiobase/alpine:3.12
 
-RUN apk --no-cache add rclone
-
-RUN rclone version
+COPY --from=downloader /rclone /usr/bin/rclone
 
 RUN apk add --no-cache gettext fuse
+
+RUN rclone version
 
 RUN sed -i 's/#user_allow_other/user_allow_other/' /etc/fuse.conf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine:3.11 as downloader
+FROM lsiobase/alpine:3.12 as downloader
 
 ARG VERSION=current
 


### PR DESCRIPTION
By using `current` the newest version is downloaded form the rclone site. Other versions can be specified by their version number. E.g.: v1.54.0
